### PR TITLE
Fix ownership of components

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ ember install ember-curry-component
 
 ```gjs
 import Component from "@glimmer/component";
+import { getOwner } from "@ember/owner";
 import curryComponent from "ember-curry-component";
 import SomeOtherComponent from "./some-other-component";
 
@@ -22,7 +23,7 @@ class MyComponent extends Component {
     const args = {
       name: "David"
     };
-    return curryComponent(SomeOtherComponent, args)
+    return curryComponent(SomeOtherComponent, args, getOwner(this))
   }
 
   <template>
@@ -35,6 +36,7 @@ class MyComponent extends Component {
 
 ```gjs
 import Component from "@glimmer/component";
+import { getOwner } from "@ember/owner";
 import curryComponent from "ember-curry-component";
 import SomeOtherComponent from "./some-other-component";
 
@@ -48,7 +50,7 @@ class MyComponent extends Component {
         return instance.name;
       }
     };
-    return curryComponent(SomeOtherComponent, args);
+    return curryComponent(SomeOtherComponent, args, getOwner(this));
   }
 
   <template>
@@ -62,6 +64,7 @@ When `this.name` is reassigned, the `@name` argument on the curried component wi
 
 ```gjs
 import Component from "@glimmer/component";
+import { getOwner } from "@ember/owner";
 import curryComponent from "ember-curry-component";
 import SomeOtherComponent from "./some-other-component";
 
@@ -72,7 +75,7 @@ class MyComponent extends Component {
     const args = {
       name: this.name
     };
-    return curryComponent(SomeOtherComponent, args);
+    return curryComponent(SomeOtherComponent, args, getOwner(this));
   }
 
   <template>
@@ -84,7 +87,7 @@ When `this.name` is reassigned, the `curriedComponent` getter will be invalidate
 
 ### As a helper
 
-In `.gjs`/`.gjs` files, the curryComponent helper can be used directly in a template.
+In `.gjs`/`.gjs` files, the curryComponent helper can be used directly in a template. In this case, the owner does not need to be passed explicitly.
 
 ```gjs
 import SomeOtherComponent from "./some-other-component";
@@ -104,13 +107,13 @@ In `<template>`, curried components cannot be rendered from the local scope. Thi
 
 ```gjs
 // Do not copy!
-const curried = curryComponent(MyComponent, args)
+const curried = curryComponent(MyComponent, args, owner)
 <template><curried /></template>
 ```
 You must wrap the invocation in `{{#let}}` instead:
 ```gjs
 // Do not copy!
-const curried = curryComponent(MyComponent, args)
+const curried = curryComponent(MyComponent, args, owner)
 <template>
   {{#let curried as |myComponent|}}
     <myComponent />

--- a/ember-curry-component/package.json
+++ b/ember-curry-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-curry-component",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Like Ember's builtin `(component)` helper, but with dynamic arguments, and JS compatibility",
   "keywords": [
     "ember-addon"

--- a/ember-curry-component/src/index.js
+++ b/ember-curry-component/src/index.js
@@ -2,6 +2,7 @@ import { createComputeRef } from '@glimmer/reference';
 import { createCapturedArgs, curry, EMPTY_POSITIONAL } from '@glimmer/runtime';
 import { dict } from '@glimmer/util';
 import * as vm from '@glimmer/vm';
+import { setHelperManager, capabilities } from '@ember/helper';
 
 // CurriedType only made available in vm from Ember 5.6.0. Fallback to hardcoded value.
 const ComponentCurriedType = vm.CurriedType?.Component || 0;
@@ -11,8 +12,16 @@ const ComponentCurriedType = vm.CurriedType?.Component || 0;
  *
  * @param {Component} componentKlass - The component class to curry
  * @param {Object} namedArgs - Named arguments to curry the component with. The set of keys must be static, but the values can be dynamic (e.g. getters, or a Proxy)
+ * @param {ApplicationInstance} owner - The owner to use for the curried component
+
  */
-export default function curryComponent(componentKlass, namedArgs) {
+export default function curryComponent(componentKlass, namedArgs, owner) {
+  if (!namedArgs || !componentKlass || !owner) {
+    throw new Error(
+      'curryComponent requires a component class, named arguments, and an owner',
+    );
+  }
+
   let namedDict = dict();
 
   for (const key of Object.keys(namedArgs)) {
@@ -22,8 +31,37 @@ export default function curryComponent(componentKlass, namedArgs) {
   return curry(
     ComponentCurriedType,
     componentKlass,
-    {},
+    owner,
     createCapturedArgs(namedDict, EMPTY_POSITIONAL),
     false,
   );
 }
+
+/**
+ * Like the default function helper manager,
+ * but also passes the owner as a final argument.
+ */
+class CurryComponentHelperManager {
+  capabilities = capabilities('3.23', {
+    hasValue: true,
+    hasDestroyable: false,
+    hasScheduledEffect: false,
+  });
+
+  constructor(owner) {
+    this.owner = owner;
+  }
+
+  createHelper(fn, args) {
+    return { fn, args };
+  }
+
+  getValue({ fn, args }) {
+    return fn(...args.positional, this.owner);
+  }
+}
+
+setHelperManager(
+  (owner) => new CurryComponentHelperManager(owner),
+  curryComponent,
+);

--- a/test-app/app/components/resolvable-component.hbs
+++ b/test-app/app/components/resolvable-component.hbs
@@ -1,0 +1,1 @@
+<div class="one">{{@one}}</div><div class="two">{{@two}}</div>


### PR DESCRIPTION
49290a6b301d118ee7a9406139bd7caabb1abe5b removed the required `owner` parameter, because it seemed unnecessary in the simple case. However, it is actually required if anything in the tree below your curried component needs to resolve something (e.g. services, or invokables in loose-mode templates).

This commit restores the `getOwner()` requirement when using via JS, and adds a custom helper manager so that it is passed automatically when curryComponent is used directly in a template.