### PR TITLE
Support nesting & re-use of curried instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ const curried = curryComponent(MyComponent, args, owner)
 ```
 You must wrap the invocation in `{{#let}}` instead:
 ```gjs
-// Do not copy!
 const curried = curryComponent(MyComponent, args, owner)
 <template>
   {{#let curried as |myComponent|}}

--- a/ember-curry-component/package.json
+++ b/ember-curry-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-curry-component",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Like Ember's builtin `(component)` helper, but with dynamic arguments, and JS compatibility",
   "keywords": [
     "ember-addon"

--- a/ember-curry-component/src/index.js
+++ b/ember-curry-component/src/index.js
@@ -1,9 +1,10 @@
 import { createComputeRef } from '@glimmer/reference';
 import { createCapturedArgs, curry, EMPTY_POSITIONAL } from '@glimmer/runtime';
-import { dict } from '@glimmer/util';
 import { setHelperManager, capabilities } from '@ember/helper';
 
 const ComponentCurriedType = 0;
+
+const CACHE = new WeakMap();
 
 /**
  * Curry a component with named arguments.
@@ -20,19 +21,33 @@ export default function curryComponent(componentKlass, namedArgs, owner) {
     );
   }
 
-  let namedDict = dict();
-
-  for (const key of Object.keys(namedArgs)) {
-    namedDict[key] = createComputeRef(() => namedArgs[key]);
+  let componentCache = CACHE.get(componentKlass);
+  if (componentCache?.has(namedArgs)) {
+    return componentCache.get(namedArgs);
   }
 
-  return curry(
+  const argRefsProxy = new Proxy(namedArgs, {
+    get(target, prop) {
+      return createComputeRef(() => target[prop]);
+    },
+  });
+
+  const result = curry(
     ComponentCurriedType,
     componentKlass,
     owner,
-    createCapturedArgs(namedDict, EMPTY_POSITIONAL),
+    createCapturedArgs(argRefsProxy, EMPTY_POSITIONAL),
     false,
   );
+
+  if (!componentCache) {
+    componentCache = new WeakMap();
+    CACHE.set(componentKlass, componentCache);
+  }
+
+  componentCache.set(namedArgs, result);
+
+  return result;
 }
 
 /**

--- a/test-app/tests/integration/curried-component-test.gjs
+++ b/test-app/tests/integration/curried-component-test.gjs
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "test-app/tests/helpers";
 import { tracked, cached } from "@glimmer/tracking";
-import { render, settled } from "@ember/test-helpers";
+import { fillIn, render, settled } from "@ember/test-helpers";
 import curryComponent from "ember-curry-component";
 import { hbs } from "ember-cli-htmlbars";
 import Component from "@glimmer/component";
@@ -252,5 +252,121 @@ module("Integration | curryComponent", function (hooks) {
 
     assert.dom(".one").hasText("one");
     assert.dom(".two").hasText("two");
+  });
+
+  test("does not rerender unnecessarily", async function (assert) {
+    const owner = getOwner(this);
+
+    const data = new (class {
+      @tracked component;
+      args = {};
+
+      get curriedComponent() {
+        return curryComponent(this.component, this.args, owner);
+      }
+    })();
+
+    data.component = <template>
+      {{!template-lint-disable}}
+      Foobar
+      <input type="text" />
+    </template>;
+
+    await render(
+      <template>
+        {{#let data.curriedComponent as |Comp|}}
+          <Comp />
+        {{/let}}
+      </template>,
+    );
+
+    await fillIn("input", "somecontent");
+
+    // eslint-disable-next-line no-self-assign
+    data.component = data.component;
+    await settled();
+
+    assert.dom("input").hasValue("somecontent");
+  });
+
+  test("dynamic arguments", async function (assert) {
+    const args = {
+      one: "one",
+      two: "two",
+    };
+
+    const comp = <template>
+      <div class="one">
+        {{@one}}
+      </div>
+      <div class="two">
+        {{@two}}
+      </div>
+      <div class="three">
+        {{@three}}
+      </div>
+    </template>;
+
+    const curriedComponent = curryComponent(comp, args, getOwner(this));
+
+    await render(
+      <template>
+        {{#let curriedComponent as |Comp|}}
+          <Comp />
+        {{/let}}
+      </template>,
+    );
+
+    assert.dom(".one").hasText("one");
+    assert.dom(".two").hasText("two");
+    assert.dom(".three").hasNoText("three");
+
+    args.three = "three";
+    await settled();
+    assert.dom(".one").hasText("one");
+    assert.dom(".two").hasText("two");
+    assert.dom(".three").hasNoText("three"); // Adding arg keys not supported
+
+    const newCurriedComponent = curryComponent(comp, args, getOwner(this));
+
+    await render(
+      <template>
+        {{#let newCurriedComponent as |Comp|}}
+          <Comp />
+        {{/let}}
+      </template>,
+    );
+
+    assert.dom(".one").hasText("one");
+    assert.dom(".two").hasText("two");
+    assert.dom(".three").hasText("three");
+  });
+
+  test("nested curryComponent calls", async function (assert) {
+    const comp = <template>
+      <div class="one">
+        {{@one}}
+      </div>
+      <div class="two">
+        {{@two}}
+      </div>
+    </template>;
+
+    const doubleCurried = curryComponent(
+      curryComponent(comp, { one: "hello" }, getOwner(this)),
+      { two: "world" },
+      getOwner(this),
+    );
+
+    await render(
+      <template>
+        {{#let doubleCurried as |Comp|}}
+          <Comp />
+        {{/let}}
+      </template>,
+    );
+
+    assert.dom(".one").hasText("hello");
+    assert.dom(".two").hasText("world");
   });
 });


### PR DESCRIPTION
- Nested calls to curryComponent are now allowed

- If the same component & argument object are passed, the curried reference will be re-used, which prevents any unnecessary rendering. This matches Ember's built-in `(component` helper.